### PR TITLE
H2H Team 2 parameter fix

### DIFF
--- a/src/Endpoint/Head2Head.php
+++ b/src/Endpoint/Head2Head.php
@@ -20,7 +20,7 @@ class Head2Head extends SoccerClient
      */
     public function getByTeamIds(int $team1Id, int $team2Id)
     {
-        $url = "head2head/{$team1Id}/$team2Id}";
+        $url = "head2head/{$team1Id}/{$team2Id}";
         return $this->call($url);
     }
 }


### PR DESCRIPTION
Fixed parameter for H2H statistics. Missing "{" which led to wrong URL query and crashed.